### PR TITLE
paper: properly mark up references

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,7 @@
+@Article{biogo,
+  author  = {Kortschak, R. D. and Adelson, D. L.},
+  title   = {bíogo: a simple high-performance bioinformatics toolkit for the Go language},
+  journal = {bioRxiv},
+  year    = {2014},
+  doi     = {10.1101/005033},
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -22,15 +22,14 @@ affiliations:
  - name: Department of Pathology and Laboratory Medicine, Perelman School of Medicine, University of Pennsylvania
    index: 2
 date: 6 January 2017
+bibliography: paper.bib
 ---
 
 # Summary
 
-bíogo is a framework designed to ease development and maintenance of computationally intensive bioinformatics applications (Kortschak and Adelson, 2014).
+bíogo is a framework designed to ease development and maintenance of computationally intensive bioinformatics applications [@biogo].
 The library is written in the Go programming language, a garbage-collected, strictly typed compiled language with built in support for concurrent processing, and performance comparable to C and Java.
 It provides a variety of data types and utility functions to facilitate manipulation and analysis of large scale genomic and other biological data. bíogo uses a concise and expressive syntax, lowering the barriers to entry for researchers needing to process large data sets with custom analyses while retaining computational safety and ease of code review.
 We believe bíogo provides an excellent environment for training and research in computational biology because of its combination of strict typing, simple and expressive syntax, and high performance.
 
 # References
-
-Kortschak, R. D. and Adelson, D. L. (2014) "bíogo: a simple high-performance bioinformatics toolkit for the Go language" bioRxiv doi:[10.1101/005033](http://biorxiv.org/content/early/2015/03/27/005033)


### PR DESCRIPTION
@dadelson Please take a look.

This fixes the reference formatting for JOSS