### PR TITLE
align: fix final segment score for affine NW backtrack

### DIFF
--- a/align/align_test.go
+++ b/align/align_test.go
@@ -5,6 +5,7 @@
 package align
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -22,6 +23,32 @@ type S struct{}
 var _ = check.Suite(&S{})
 
 func (s *S) TestWarning(c *check.C) { c.Log("\nFIXME: Tests only in example tests.\n") }
+
+// https://github.com/biogo/biogo/issues/58
+func (s *S) TestIssue58(c *check.C) {
+	a := "GCTCACTAAAAACACAATCTACAACAGACGTTGCACTAACACTGTAATTGCCTTTAGTCC"
+	b := "ACTGCGTA"
+
+	nwsa := &linear.Seq{Seq: alphabet.BytesToLetters([]byte(a))}
+	nwsa.Alpha = alphabet.DNAgapped
+	nwsb := &linear.Seq{Seq: alphabet.BytesToLetters([]byte(b))}
+	nwsb.Alpha = alphabet.DNAgapped
+
+	needle := NWAffine{
+		Matrix: Linear{
+			{0, -1, -1, -1, -1},
+			{-1, 1, -1, -1, -1},
+			{-1, -1, 1, -1, -1},
+			{-1, -1, -1, 1, -1},
+			{-1, -1, -1, -1, 1},
+		},
+		GapOpen: -1,
+	}
+
+	aln, err := needle.Align(nwsa, nwsb)
+	c.Check(err, check.Equals, nil)
+	c.Check(fmt.Sprint(aln), check.Equals, "[[0,4)/-=-5 [4,7)/[0,3)=3 [7,32)/-=-26 [32,34)/[3,5)=2 [34,43)/-=-10 [43,46)/[5,8)=3 [46,60)/-=-15]")
+}
 
 func BenchmarkSWAlign(b *testing.B) {
 	t := &linear.Seq{}

--- a/align/nw_affine_letters.go
+++ b/align/nw_affine_letters.go
@@ -309,6 +309,14 @@ func (a NWAffine) alignLetters(rSeq, qSeq alphabet.Letters, alpha alphabet.Alpha
 		score: score,
 	})
 	if i != j {
+		switch 0 {
+		case i:
+			last = left
+		case j:
+			last = up
+		default:
+			panic(fmt.Sprintf("align: nw affine internal error: unexpected final segment: row: %d col: %d", i, j))
+		}
 		aln = append(aln, &featPair{
 			a:     feature{start: 0, end: i},
 			b:     feature{start: 0, end: j},

--- a/align/nw_affine_qletters.go
+++ b/align/nw_affine_qletters.go
@@ -309,6 +309,14 @@ func (a NWAffine) alignQLetters(rSeq, qSeq alphabet.QLetters, alpha alphabet.Alp
 		score: score,
 	})
 	if i != j {
+		switch 0 {
+		case i:
+			last = left
+		case j:
+			last = up
+		default:
+			panic(fmt.Sprintf("align: nw affine internal error: unexpected final segment: row: %d col: %d", i, j))
+		}
 		aln = append(aln, &featPair{
 			a:     feature{start: 0, end: i},
 			b:     feature{start: 0, end: j},

--- a/align/nw_affine_type.got
+++ b/align/nw_affine_type.got
@@ -307,6 +307,14 @@ func (a NWAffine) alignType(rSeq, qSeq Type, alpha alphabet.Alphabet) ([]feat.Pa
 		score: score,
 	})
 	if i != j {
+		switch 0 {
+		case i:
+			last = left
+		case j:
+			last = up
+		default:
+			panic(fmt.Sprintf("align: nw affine internal error: unexpected final segment: row: %d col: %d", i, j))
+		}
 		aln = append(aln, &featPair{
 			a:     feature{start: 0, end: i},
 			b:     feature{start: 0, end: j},


### PR DESCRIPTION
@bsipsos Please take a look.

Fixes #58.