### PR TITLE
Change Pairing.ComplementTable to pre-compute the table.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,4 +19,5 @@ Josh Bleecher Snyder <josharian@gmail.com>
 Olga Botvinnik <olga.botvinnik@gmail.com>
 Peter Mattis <petermattis@gmail.com>
 Senthil Murugapiran <senthil.murugapiran@inra.fr>
+Yaz Saito <yasushi.saito@gmail.com>
 The University of Adelaide

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,3 +25,4 @@ Josh Bleecher Snyder <josharian@gmail.com>
 Olga Botvinnik <olga.botvinnik@gmail.com>
 Peter Mattis <petermattis@gmail.com>
 Senthil Murugapiran <senthil.murugapiran@inra.fr>
+Yaz Saito <yasushi.saito@gmail.com>

--- a/alphabet/alphabet.go
+++ b/alphabet/alphabet.go
@@ -257,8 +257,8 @@ func (a *alpha) Letters() string      { return a.letters }
 
 // A Pairing provides a lookup table between a letter and its complement.
 type Pairing struct {
-	pair []Letter
-	ok   []bool
+	pair        []Letter
+	ok          []bool
 	complements [256]Letter
 }
 

--- a/alphabet/alphabet.go
+++ b/alphabet/alphabet.go
@@ -307,6 +307,7 @@ func NewPairing(s, c string) (*Pairing, error) {
 func (p *Pairing) Complement(l Letter) (c Letter, ok bool) { return p.pair[l], p.ok[l] }
 
 // Returns a complementation table based on the internal representation. Invalid pairs hold a value outside the ASCII range.
+// The caller must not modify the returned table.
 func (p *Pairing) ComplementTable() []Letter {
 	return p.complements[:]
 }

--- a/alphabet/alphabet.go
+++ b/alphabet/alphabet.go
@@ -259,6 +259,7 @@ func (a *alpha) Letters() string      { return a.letters }
 type Pairing struct {
 	pair []Letter
 	ok   []bool
+	complements [256]Letter
 }
 
 // NewPairing create a new Pairing from a pair of strings. Pairing definitions must be
@@ -293,7 +294,12 @@ func NewPairing(s, c string) (*Pairing, error) {
 			return nil, errors.New("alphabet: pairing definition is not a bijection")
 		}
 	}
-
+	copy(p.complements[:], p.pair)
+	for i, ok := range p.ok {
+		if !ok {
+			p.complements[i] |= unicode.MaxASCII + 1
+		}
+	}
 	return p, nil
 }
 
@@ -301,16 +307,8 @@ func NewPairing(s, c string) (*Pairing, error) {
 func (p *Pairing) Complement(l Letter) (c Letter, ok bool) { return p.pair[l], p.ok[l] }
 
 // Returns a complementation table based on the internal representation. Invalid pairs hold a value outside the ASCII range.
-func (p *Pairing) ComplementTable() (t []Letter) {
-	t = make([]Letter, 256)
-	copy(t, p.pair)
-	for i, ok := range p.ok {
-		if !ok {
-			t[i] |= unicode.MaxASCII + 1
-		}
-	}
-
-	return
+func (p *Pairing) ComplementTable() []Letter {
+	return p.complements[:]
 }
 
 type nucleic struct {

--- a/seq/linear/linear_test.go
+++ b/seq/linear/linear_test.go
@@ -7,6 +7,7 @@ package linear
 import (
 	"testing"
 
+	"github.com/biogo/biogo/alphabet"
 	"gopkg.in/check.v1"
 )
 
@@ -18,3 +19,11 @@ type S struct{}
 var _ = check.Suite(&S{})
 
 func (s *S) TestWarning(c *check.C) { c.Log("\nFIXME: Tests only in example tests.\n") }
+
+func BenchmarkRevComp(b *testing.B) {
+	in := []alphabet.Letter("ATGCtGACTTGGTGCACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTATGCtGACTTGGTGCACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTATGCtGACTTGGTGCACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTATGCtGACTTGGTGCACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTATGCtGACTTGGTGCACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT")
+	for i := 0; i < b.N; i++ {
+		s := NewSeq("example DNA", in, alphabet.DNA)
+		s.RevComp()
+	}
+}


### PR DESCRIPTION
It improves the performance of RevComp, etc.  It also reduces heap pressures.

Before:
BenchmarkRevComp-56      1000000              1518 ns/op                                                                                                      

After:
BenchmarkRevComp-56      2000000               704 ns/op                        

It causes the ComplementTable to return a shared table instance. All the uses found in biogo aren't affected by this change.                                                                              

