### PR TITLE
Provide custom-typed Error handling

### DIFF
--- a/align/fitted_affine_letters.go
+++ b/align/fitted_affine_letters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -138,10 +139,10 @@ func (a FittedAffine) alignLetters(rSeq, qSeq alphabet.Letters, alpha alphabet.A
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/fitted_affine_qletters.go
+++ b/align/fitted_affine_qletters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -138,10 +139,10 @@ func (a FittedAffine) alignQLetters(rSeq, qSeq alphabet.QLetters, alpha alphabet
 				qVal = index[qSeq[j-1].L]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1))
 			}
 			p := i*c + j
 

--- a/align/fitted_affine_type.got
+++ b/align/fitted_affine_type.got
@@ -6,6 +6,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -136,10 +137,10 @@ func (a FittedAffine) alignType(rSeq, qSeq Type, alpha alphabet.Alphabet) ([]fea
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/fitted_letters.go
+++ b/align/fitted_letters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -91,10 +92,10 @@ func (a Fitted) alignLetters(rSeq, qSeq alphabet.Letters, alpha alphabet.Alphabe
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/fitted_qletters.go
+++ b/align/fitted_qletters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -91,10 +92,10 @@ func (a Fitted) alignQLetters(rSeq, qSeq alphabet.QLetters, alpha alphabet.Alpha
 				qVal = index[qSeq[j-1].L]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1))
 			}
 			p := i*c + j
 

--- a/align/fitted_type.got
+++ b/align/fitted_type.got
@@ -6,6 +6,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -89,10 +90,10 @@ func (a Fitted) alignType(rSeq, qSeq Type, alpha alphabet.Alphabet) ([]feat.Pair
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/nw_affine_letters.go
+++ b/align/nw_affine_letters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -148,10 +149,10 @@ func (a NWAffine) alignLetters(rSeq, qSeq alphabet.Letters, alpha alphabet.Alpha
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/nw_affine_qletters.go
+++ b/align/nw_affine_qletters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -148,10 +149,10 @@ func (a NWAffine) alignQLetters(rSeq, qSeq alphabet.QLetters, alpha alphabet.Alp
 				qVal = index[qSeq[j-1].L]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1))
 			}
 			p := i*c + j
 

--- a/align/nw_affine_type.got
+++ b/align/nw_affine_type.got
@@ -6,6 +6,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -146,10 +147,10 @@ func (a NWAffine) alignType(rSeq, qSeq Type, alpha alphabet.Alphabet) ([]feat.Pa
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/nw_letters.go
+++ b/align/nw_letters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -102,10 +103,10 @@ func (a NW) alignLetters(rSeq, qSeq alphabet.Letters, alpha alphabet.Alphabet) (
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/nw_qletters.go
+++ b/align/nw_qletters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -102,10 +103,10 @@ func (a NW) alignQLetters(rSeq, qSeq alphabet.QLetters, alpha alphabet.Alphabet)
 				qVal = index[qSeq[j-1].L]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1))
 			}
 			p := i*c + j
 

--- a/align/nw_type.got
+++ b/align/nw_type.got
@@ -6,6 +6,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -100,10 +101,10 @@ func (a NW) alignType(rSeq, qSeq Type, alpha alphabet.Alphabet) ([]feat.Pair, er
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/pals/packseqs.go
+++ b/align/pals/packseqs.go
@@ -5,10 +5,10 @@
 package pals
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/seq"
 	"github.com/biogo/biogo/seq/linear"
 	"github.com/biogo/biogo/util"
@@ -37,7 +37,7 @@ func (pa *Packed) feature(from, to int, comp bool) (*Feature, error) {
 		from, to = pa.Len()-to, pa.Len()-from
 	}
 	if from >= to {
-		return nil, errors.New("pals: from > to")
+		return nil, errors.ArgErr{}.Make("pals: from > to")
 	}
 
 	// DPHit coordinates sometimes over/underflow.
@@ -56,19 +56,19 @@ func (pa *Packed) feature(from, to int, comp bool) (*Feature, error) {
 	binCount := (pa.Len() + binSize - 1) / binSize
 
 	if bin < 0 || bin >= binCount {
-		return nil, fmt.Errorf("pals: bin %d out of range 0..%d", bin, binCount-1)
+		return nil, errors.ArgErr{}.Make(fmt.Sprintf("pals: bin %d out of range 0..%d", bin, binCount-1))
 	}
 
 	contigIndex := pa.seqMap.binMap[bin]
 
 	if contigIndex < 0 || contigIndex >= len(pa.seqMap.contigs) {
-		return nil, fmt.Errorf("pals: contig %s index %d out of range 0..%d", pa.ID, contigIndex, len(pa.seqMap.contigs))
+		return nil, errors.ArgErr{}.Make(fmt.Sprintf("pals: contig %s index %d out of range 0..%d", pa.ID, contigIndex, len(pa.seqMap.contigs)))
 	}
 
 	length := to - from
 
 	if length < 0 {
-		return nil, errors.New("pals: length < 0")
+		return nil, errors.ArgErr{}.Make("pals: length < 0")
 	}
 
 	contig := pa.seqMap.contigs[contigIndex]
@@ -106,7 +106,7 @@ func (pa *Packer) Pack(seq *linear.Seq) (string, error) {
 	if pa.packed.Alpha == nil {
 		pa.packed.Alpha = seq.Alpha
 	} else if pa.packed.Alpha != seq.Alpha {
-		return "", errors.New("pals: alphabet mismatch")
+		return "", errors.ArgErr{}.Make("pals: alphabet mismatch")
 	}
 
 	c := contig{Seq: seq}

--- a/align/pals/pair.go
+++ b/align/pals/pair.go
@@ -6,6 +6,7 @@ package pals
 
 import (
 	"github.com/biogo/biogo/align/pals/dp"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/io/featio/gff"
 	"github.com/biogo/biogo/seq"
 
@@ -63,11 +64,11 @@ func NewPair(target, query *Packed, hit dp.Hit, comp bool) (*Pair, error) {
 func ExpandFeature(f *gff.Feature) (*Pair, error) {
 	targ := f.FeatAttributes.Get("Target")
 	if targ == "" {
-		return nil, fmt.Errorf("pals: not a feature pair")
+		return nil, errors.ArgErr{}.Make(fmt.Sprintf("pals: not a feature pair"))
 	}
 	fields := strings.Fields(targ)
 	if len(fields) != 3 {
-		return nil, fmt.Errorf("pals: not a feature pair")
+		return nil, errors.ArgErr{}.Make(fmt.Sprintf("pals: not a feature pair"))
 	}
 
 	s, err := strconv.Atoi(fields[1])

--- a/align/pals/piler.go
+++ b/align/pals/piler.go
@@ -8,11 +8,12 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 	"github.com/biogo/store/interval"
 )
 
-var duplicatePair = fmt.Errorf("pals: attempt to add duplicate feature pair to pile")
+var duplicatePair = errors.ArgErr{}.Make(fmt.Sprintf("pals: attempt to add duplicate feature pair to pile"))
 
 // Note Location must be comparable according to http://golang.org/ref/spec#Comparison_operators.
 type pileInterval struct {

--- a/align/sw_affine_letters.go
+++ b/align/sw_affine_letters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -112,10 +113,10 @@ func (a SWAffine) alignLetters(rSeq, qSeq alphabet.Letters, alpha alphabet.Alpha
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/sw_affine_qletters.go
+++ b/align/sw_affine_qletters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -112,10 +113,10 @@ func (a SWAffine) alignQLetters(rSeq, qSeq alphabet.QLetters, alpha alphabet.Alp
 				qVal = index[qSeq[j-1].L]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1))
 			}
 			p := i*c + j
 

--- a/align/sw_affine_type.got
+++ b/align/sw_affine_type.got
@@ -6,6 +6,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -110,10 +111,10 @@ func (a SWAffine) alignType(rSeq, qSeq Type, alpha alphabet.Alphabet) ([]feat.Pa
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/sw_letters.go
+++ b/align/sw_letters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -95,10 +96,10 @@ func (a SW) alignLetters(rSeq, qSeq alphabet.Letters, alpha alphabet.Alphabet) (
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/align/sw_qletters.go
+++ b/align/sw_qletters.go
@@ -8,6 +8,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -95,10 +96,10 @@ func (a SW) alignQLetters(rSeq, qSeq alphabet.QLetters, alpha alphabet.Alphabet)
 				qVal = index[qSeq[j-1].L]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1].L, i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1].L, j-1))
 			}
 			p := i*c + j
 

--- a/align/sw_type.got
+++ b/align/sw_type.got
@@ -6,6 +6,7 @@ package align
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/feat"
 
 	"fmt"
@@ -93,10 +94,10 @@ func (a SW) alignType(rSeq, qSeq Type, alpha alphabet.Alphabet) ([]feat.Pair, er
 				qVal = index[qSeq[j-1]]
 			)
 			if rVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in rSeq", rSeq[i-1], i-1))
 			}
 			if qVal < 0 {
-				return nil, fmt.Errorf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("align: illegal letter %q at position %d in qSeq", qSeq[j-1], j-1))
 			}
 			p := i*c + j
 

--- a/complexity/complexity.go
+++ b/complexity/complexity.go
@@ -6,6 +6,7 @@
 package complexity
 
 import (
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/seq"
 
 	"compress/zlib"
@@ -47,7 +48,7 @@ func logBaseK(logk, x float64) float64 {
 // start and end.
 func Entropic(s seq.Sequence, start, end int) (ce float64, err error) {
 	if start < s.Start() || end > s.End() {
-		err = fmt.Errorf("complex: index out of range")
+		err = errors.ArgErr{}.Make(fmt.Sprintf("complex: index out of range"))
 		return
 	}
 	if start == end {
@@ -83,7 +84,7 @@ func Entropic(s seq.Sequence, start, end int) (ce float64, err error) {
 // start and end.
 func WF(s seq.Sequence, start, end int) (cwf float64, err error) {
 	if start < s.Start() || end > s.End() {
-		err = fmt.Errorf("complex: index out of range")
+		err = errors.ArgErr{}.Make(fmt.Sprintf("complex: index out of range"))
 		return
 	}
 	if start == end {
@@ -136,7 +137,7 @@ func calcOverhead() byteCounter {
 // start and end.
 func Z(s seq.Sequence, start, end int) (cz float64, err error) {
 	if start < s.Start() || end > s.End() {
-		err = fmt.Errorf("complex: index out of range")
+		err = errors.ArgErr{}.Make(fmt.Sprintf("complex: index out of range"))
 		return
 	}
 	if start == end {

--- a/concurrent/map.go
+++ b/concurrent/map.go
@@ -5,6 +5,7 @@
 package concurrent
 
 import (
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/util"
 
 	"fmt"
@@ -48,7 +49,7 @@ func Map(set Mapper, threads, maxChunkSize int) (results []interface{}, err erro
 	for r := 0; r*chunkSize < set.Len(); r++ {
 		result := <-p.out
 		if result.Err != nil {
-			err = fmt.Errorf("concurrent: map failed: %v", err)
+			err = errors.ConcurrencyErr{}.Make(fmt.Sprintf("concurrent: map failed: %v", err))
 			close(quit)
 			break
 		}

--- a/concurrent/processor.go
+++ b/concurrent/processor.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+
+	"github.com/biogo/biogo/errors"
 )
 
 // Interface is a type that performs an operation on itself, returning any error.
@@ -51,7 +53,7 @@ func NewProcessor(queue chan Operator, buffer int, threads int) (p *Processor) {
 			<-p.work
 			defer func() {
 				if err := recover(); err != nil {
-					p.out <- Result{nil, fmt.Errorf("concurrent: processor panic: %v", err)}
+					p.out <- Result{nil, errors.ConcurrencyErr{}.Make(fmt.Sprintf("concurrent: processor panic: %v", err))}
 				}
 				p.work <- struct{}{}
 				if len(p.work) == p.threads {

--- a/concurrent/promise.go
+++ b/concurrent/promise.go
@@ -5,9 +5,10 @@
 package concurrent
 
 import (
-	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/biogo/biogo/errors"
 )
 
 // Implementation of a promise multiple goroutine synchronisation and communication system
@@ -64,19 +65,19 @@ func (p *Promise) fulfill(value interface{}) (err error) {
 	r, set := p.messageState()
 
 	if r.Err != nil {
-		err = fmt.Errorf("concurrent: attempt to fulfill failed promise: %v", r.Err)
+		err = errors.ConcurrencyErr{}.Make(fmt.Sprintf("concurrent: attempt to fulfill failed promise: %v", r.Err))
 	} else {
 		if !set || p.mutable {
 			r.Value = value
 			err = nil
 		} else {
-			err = errors.New("concurrent: attempt to fulfill already set immutable promise")
+			err = errors.ConcurrencyErr{}.Make("concurrent: attempt to fulfill already set immutable promise")
 		}
 	}
 
 	if err != nil && p.relay {
 		if r.Err != nil {
-			err = fmt.Errorf("concurrent: promise already failed - cannot relay: %v", r.Err)
+			err = errors.ConcurrencyErr{}.Make(fmt.Sprintf("concurrent: promise already failed - cannot relay: %v", r.Err))
 		} else {
 			r.Err = err
 		}

--- a/feat/gene/gene.go
+++ b/feat/gene/gene.go
@@ -16,8 +16,9 @@ package gene
 import (
 	"github.com/biogo/biogo/feat"
 
-	"errors"
 	"sort"
+
+	"github.com/biogo/biogo/errors"
 )
 
 const maxInt = int(^uint(0) >> 1) // The maximum int value.
@@ -100,7 +101,7 @@ func (g *Gene) SetFeatures(feats ...feat.Feature) error {
 	end := 0
 	for _, f := range feats {
 		if f.Location() != g {
-			return errors.New("transcript location does not match the gene")
+			return errors.TranscriptLocationMismatchesGeneErr{}.Make("transcript location does not match the gene")
 		}
 		if f.Start() < pos {
 			pos = f.Start()
@@ -110,7 +111,7 @@ func (g *Gene) SetFeatures(feats ...feat.Feature) error {
 		}
 	}
 	if pos != 0 {
-		return errors.New("no transcript with 0 start on gene")
+		return errors.NoZeroStartTranscriptErr{}.Make("no transcript with 0 start on gene")
 	}
 	g.length = end - pos
 	g.feats = feats
@@ -363,15 +364,15 @@ func (s Exons) Add(exons ...Exon) (Exons, error) {
 	sort.Sort(newSlice)
 	for i, e := range newSlice {
 		if i != 0 && e.Start() < newSlice[i-1].End() {
-			return s, errors.New("exons overlap")
+			return s, errors.ExonOverlapErr{}.Make("exons overlap")
 		}
 		if i != 0 && e.Location() != newSlice[i-1].Location() {
-			return s, errors.New("exons location differ")
+			return s, errors.ExonLocationDiffersErr{}.Make("exons location differ")
 		}
 
 	}
 	if s.Location() != nil && s.Location() != newSlice.Location() {
-		return s, errors.New("new exons locations differ from old ones")
+		return s, errors.NewExonLocationDiffersErr{}.Make("new exons locations differ from old ones")
 	}
 	return newSlice, nil
 }
@@ -514,10 +515,10 @@ func buildExonsFor(t Transcript, exons ...Exon) (Exons, error) {
 		return newExons, err
 	}
 	if newExons.Location() != t {
-		return newExons, errors.New("exon location is not the transcript")
+		return newExons, errors.ExonNotInTranscriptErr{}.Make("exon location is not the transcript")
 	}
 	if newExons.Start() != 0 {
-		return newExons, errors.New("no exon with a zero start")
+		return newExons, errors.NoZeroStartExonErr{}.Make("no exon with a zero start")
 	}
 	return newExons, nil
 }

--- a/index/kmerindex/kmerindex.go
+++ b/index/kmerindex/kmerindex.go
@@ -7,10 +7,11 @@
 package kmerindex
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"unsafe"
+
+	"github.com/biogo/biogo/errors"
 
 	"github.com/biogo/biogo/alphabet"
 	"github.com/biogo/biogo/seq/linear"
@@ -18,13 +19,13 @@ import (
 )
 
 var (
-	ErrKTooLarge      = errors.New("kmerindex: k too large")
-	ErrKTooSmall      = errors.New("kmerindex: k too small")
-	ErrShortSeq       = errors.New("kmerindex: sequence to short for k")
-	ErrBadAlphabet    = errors.New("kmerindex: alphabet size != 4")
-	ErrBadKmer        = errors.New("kmerindex: kmer out of range")
-	ErrBadKmerTextLen = errors.New("kmerindex: kmertext length != k")
-	ErrBadKmerText    = errors.New("kmerindex: kmertext contains illegal character")
+	ErrKTooLarge      = errors.KTooLargeErr{}.Make("kmerindex: k too large")
+	ErrKTooSmall      = errors.KTooSmallErr{}.Make("kmerindex: k too small")
+	ErrShortSeq       = errors.KSeqTooShortErr{}.Make("kmerindex: sequence to short for k")
+	ErrBadAlphabet    = errors.InvalidAlphabetErr{}.Make("kmerindex: alphabet size != 4")
+	ErrBadKmer        = errors.BadKmerErr{}.Make("kmerindex: kmer out of range")
+	ErrBadKmerTextLen = errors.BadKmerTextLenErr{}.Make("kmerindex: kmertext length != k")
+	ErrBadKmerText    = errors.IllegalKmerTextErr{}.Make("kmerindex: kmertext contains illegal character")
 )
 
 // Constraints on Kmer length.
@@ -111,7 +112,7 @@ func (ki *Index) KmerPositionsString(kmertext string) (positions []int, err erro
 	case len(kmertext) != ki.k:
 		return nil, ErrBadKmerTextLen
 	case !ki.indexed:
-		return nil, errors.New("kmerindex: index not built: call Build()")
+		return nil, errors.StateErr{}.Make("kmerindex: index not built: call Build()")
 	}
 
 	var kmer Kmer

--- a/io/featio/bed/bed.go
+++ b/io/featio/bed/bed.go
@@ -16,7 +16,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/csv"
-	"errors"
 	"fmt"
 	"image/color"
 	"io"
@@ -24,15 +23,17 @@ import (
 	"runtime"
 	"strconv"
 	"unsafe"
+
+	"github.com/biogo/biogo/errors"
 )
 
 var (
-	ErrBadBedType         = errors.New("bed: bad bed type")
-	ErrBadStrandField     = errors.New("bad strand field")
-	ErrBadStrand          = errors.New("invalid strand")
-	ErrBadColorField      = errors.New("bad color field")
-	ErrMissingBlockValues = errors.New("missing block values")
-	ErrNoChromField       = errors.New("no chrom field available")
+	ErrBadBedType         = errors.BadBedTypeErr{}.Make("bed: bad bed type")
+	ErrBadStrandField     = errors.BadStrandFieldErr{}.Make("bad strand field")
+	ErrBadStrand          = errors.BadStrandErr{}.Make("invalid strand")
+	ErrBadColorField      = errors.BadColorFieldErr{}.Make("bad color field")
+	ErrMissingBlockValues = errors.MissingBlockValuesErr{}.Make("missing block values")
+	ErrNoChromField       = errors.MissingChromFieldErr{}.Make("no chrom field available")
 )
 
 const (
@@ -403,7 +404,7 @@ func (r *Reader) Read() (f feat.Feature, err error) {
 			err.Line = r.line
 			return nil, err
 		}
-		return nil, fmt.Errorf("%v at line %d", err, r.line)
+		return nil, errors.StateErr{}.Make(fmt.Sprintf("%v at line %d", err, r.line))
 	}
 
 	return

--- a/io/featio/bed/bed_test.go
+++ b/io/featio/bed/bed_test.go
@@ -5,6 +5,8 @@
 package bed
 
 import (
+	"reflect"
+
 	"github.com/biogo/biogo/feat"
 	"github.com/biogo/biogo/seq"
 
@@ -324,7 +326,12 @@ func (s *S) TestWriteFeature(c *check.C) {
 		c.Assert(err, check.Equals, nil)
 		n, err := w.Write(f.feat)
 		c.Check(n, check.Equals, buf.Len())
-		c.Check(err, check.Equals, f.err)
+		if err != nil && f.err != nil {
+			c.Check(err.Error(), check.Equals, f.err.Error())
+			c.Check(reflect.TypeOf(err), check.Equals, reflect.TypeOf(f.err))
+		} else {
+			c.Check(err, check.Equals, f.err)
+		}
 		c.Check(buf.String(), check.Equals, f.line, check.Commentf("Test: %d type: Bed%d", i, f.typ))
 	}
 }

--- a/io/seqio/fasta/fasta.go
+++ b/io/seqio/fasta/fasta.go
@@ -7,6 +7,7 @@ package fasta
 
 import (
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/io/seqio"
 	"github.com/biogo/biogo/seq"
 
@@ -98,13 +99,13 @@ func (r *Reader) Read() (seq.Sequence, error) {
 			}
 		} else if bytes.HasPrefix(line, r.SeqPrefix) {
 			if r.working == nil {
-				return nil, fmt.Errorf("fasta: badly formed line %q", line)
+				return nil, errors.ArgErr{}.Make(fmt.Sprintf("fasta: badly formed line %q", line))
 			}
 			line = bytes.Join(bytes.Fields(line[len(r.SeqPrefix):]), nil)
 			r.working.AppendLetters(alphabet.BytesToLetters(line)...)
 			line = nil
 		} else {
-			return nil, fmt.Errorf("fasta: badly formed line %q", line)
+			return nil, errors.ArgErr{}.Make(fmt.Sprintf("fasta: badly formed line %q", line))
 		}
 	}
 }
@@ -124,7 +125,7 @@ func (r *Reader) header(line []byte) (seqio.SequenceAppender, error) {
 			case err == _err:
 				return s, err
 			case err != nil && _err != nil:
-				return s, fmt.Errorf("fasta: multiple errors: name: %s, desc:%s", err, _err)
+				return s, errors.MultiError{Errors: []error{err, _err}}.Make(fmt.Sprintf("fasta: multiple errors: name: %s, desc:%s", err, _err))
 			case err != nil:
 				return s, err
 			case _err != nil:

--- a/morass/morass.go
+++ b/morass/morass.go
@@ -16,7 +16,6 @@ package morass
 import (
 	"container/heap"
 	"encoding/gob"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,6 +24,8 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+
+	"github.com/biogo/biogo/errors"
 )
 
 var (
@@ -167,7 +168,7 @@ func New(e interface{}, prefix, dir string, chunkSize int, concurrent bool) (*Mo
 // Push a value on to the Morass. Returns any error that occurs.
 func (m *Morass) Push(e LessInterface) error {
 	if typ := reflect.TypeOf(e); typ != m.typ {
-		return fmt.Errorf("morass: type mismatch: %s != %s", typ, m.typ)
+		return errors.ArgErr{}.Make(fmt.Sprintf("morass: type mismatch: %s != %s", typ, m.typ))
 	}
 
 	if err := m.err(); err != nil {
@@ -175,7 +176,7 @@ func (m *Morass) Push(e LessInterface) error {
 	}
 
 	if m.chunk == nil {
-		return errors.New("morass: push on finalised morass")
+		return errors.StateErr{}.Make("morass: push on finalised morass")
 	}
 
 	if len(m.chunk) == m.chunkSize {
@@ -332,7 +333,7 @@ func (m *Morass) Pull(e LessInterface) error {
 	var err error
 	v := reflect.ValueOf(e)
 	if !reflect.Indirect(v).CanSet() {
-		return errors.New("morass: cannot set e")
+		return errors.StateErr{}.Make("morass: cannot set e")
 	}
 
 	if m.fast {

--- a/seq/alignment/alignment.go
+++ b/seq/alignment/alignment.go
@@ -12,10 +12,11 @@ import (
 	"github.com/biogo/biogo/seq/linear"
 	"github.com/biogo/biogo/util"
 
-	"errors"
 	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/biogo/biogo/errors"
 )
 
 // A Seq is an aligned sequence.
@@ -47,7 +48,7 @@ func NewSeq(id string, subids []string, b [][]alphabet.Letter, alpha alphabet.Al
 			}
 		}
 	default:
-		return nil, errors.New("alignment: id/seq number mismatch")
+		return nil, errors.ArgErr{}.Make("alignment: id/seq number mismatch")
 	}
 
 	return &Seq{
@@ -196,7 +197,7 @@ func (s *Seq) Row(i int) seq.Sequence {
 func (s *Seq) AppendColumns(a ...[]alphabet.QLetter) error {
 	for i, r := range a {
 		if len(r) != s.Rows() {
-			return fmt.Errorf("alignment: column %d does not match Rows(): %d != %d.", i, len(r), s.Rows())
+			return errors.ArgErr{}.Make(fmt.Sprintf("alignment: column %d does not match Rows(): %d != %d.", i, len(r), s.Rows()))
 		}
 	}
 
@@ -215,7 +216,7 @@ func (s *Seq) AppendColumns(a ...[]alphabet.QLetter) error {
 // AppendEach appends each []alphabet.QLetter in a to the appropriate sequence in the receiver.
 func (s *Seq) AppendEach(a [][]alphabet.QLetter) error {
 	if len(a) != s.Rows() {
-		return fmt.Errorf("alignment: number of sequences does not match Rows(): %d != %d.", len(a), s.Rows())
+		return errors.ArgErr{}.Make(fmt.Sprintf("alignment: number of sequences does not match Rows(): %d != %d.", len(a), s.Rows()))
 	}
 	max := util.MinInt
 	for _, ss := range a {

--- a/seq/alignment/qalignment.go
+++ b/seq/alignment/qalignment.go
@@ -11,10 +11,11 @@ import (
 	"github.com/biogo/biogo/seq/linear"
 	"github.com/biogo/biogo/util"
 
-	"errors"
 	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/biogo/biogo/errors"
 )
 
 // A QSeq is an aligned sequence with quality scores.
@@ -49,7 +50,7 @@ func NewQSeq(id string, subids []string, ql [][]alphabet.QLetter, alpha alphabet
 			}
 		}
 	default:
-		return nil, errors.New("alignment: id/seq number mismatch")
+		return nil, errors.ArgErr{}.Make("alignment: id/seq number mismatch")
 	}
 
 	return &QSeq{
@@ -212,7 +213,7 @@ func (s *QSeq) Row(i int) seq.Sequence {
 func (s *QSeq) AppendColumns(a ...[]alphabet.QLetter) error {
 	for i, c := range a {
 		if len(c) != s.Rows() {
-			return fmt.Errorf("alignment: column %d does not match Rows(): %d != %d.", i, len(c), s.Rows())
+			return errors.ArgErr{}.Make(fmt.Sprintf("alignment: column %d does not match Rows(): %d != %d.", i, len(c), s.Rows()))
 		}
 	}
 
@@ -224,7 +225,7 @@ func (s *QSeq) AppendColumns(a ...[]alphabet.QLetter) error {
 // AppendEach appends each []alphabet.QLetter in a to the appropriate sequence in the receiver.
 func (s *QSeq) AppendEach(a [][]alphabet.QLetter) error {
 	if len(a) != s.Rows() {
-		return fmt.Errorf("alignment: number of sequences does not match Rows(): %d != %d.", len(a), s.Rows())
+		return errors.ArgErr{}.Make(fmt.Sprintf("alignment: number of sequences does not match Rows(): %d != %d.", len(a), s.Rows()))
 	}
 	max := util.MinInt
 	for _, r := range a {

--- a/seq/multi/set.go
+++ b/seq/multi/set.go
@@ -5,11 +5,12 @@
 package multi
 
 import (
+	"fmt"
+
 	"github.com/biogo/biogo/alphabet"
+	"github.com/biogo/biogo/errors"
 	"github.com/biogo/biogo/seq"
 	"github.com/biogo/biogo/util"
-
-	"fmt"
 )
 
 type Set []seq.Sequence
@@ -23,7 +24,7 @@ var (
 // Append each []byte in a to the appropriate sequence in the receiver.
 func (s Set) AppendEach(a [][]alphabet.QLetter) (err error) {
 	if len(a) != s.Rows() {
-		return fmt.Errorf("multi: number of sequences does not match row count: %d != %d.", len(a), s.Rows())
+		return errors.ArgErr{}.Make(fmt.Sprintf("multi: number of sequences does not match row count: %d != %d.", len(a), s.Rows()))
 	}
 	for i, r := range s {
 		r.(seq.Appender).AppendQLetters(a[i]...)

--- a/seq/sequtils/utils.go
+++ b/seq/sequtils/utils.go
@@ -10,8 +10,9 @@ import (
 	"github.com/biogo/biogo/feat"
 	"github.com/biogo/biogo/seq"
 
-	"errors"
 	"sort"
+
+	"github.com/biogo/biogo/errors"
 )
 
 // A Joinable can be joined to another of the same concrete type using the Join function.
@@ -29,7 +30,7 @@ func Join(dst, src Joinable, where int) error {
 	srcC, srcOk := src.(seq.Conformationer)
 	switch {
 	case dstOk && dstC.Conformation() > feat.Linear, srcOk && srcC.Conformation() > feat.Linear:
-		return errors.New("sequtils: cannot join circular sequence")
+		return errors.ArgErr{}.Make("sequtils: cannot join circular sequence")
 	}
 
 	o := dst
@@ -66,7 +67,7 @@ func Truncate(dst, src Sliceable, start, end int) error {
 		offset = src.Start()
 	)
 	if start < offset || end > src.End() {
-		return errors.New("sequtils: index out of range")
+		return errors.ArgErr{}.Make("sequtils: index out of range")
 	}
 	if start <= end {
 		if dst == src {
@@ -82,10 +83,10 @@ func Truncate(dst, src Sliceable, start, end int) error {
 	}
 
 	if src, ok := src.(seq.Conformationer); !ok || src.Conformation() == feat.Linear {
-		return errors.New("sequtils: start position greater than end position for linear sequence")
+		return errors.ArgErr{}.Make("sequtils: start position greater than end position for linear sequence")
 	}
 	if end < offset || start > src.End() {
-		return errors.New("sequtils: index out of range")
+		return errors.ArgErr{}.Make("sequtils: index out of range")
 	}
 	t := sl.Make(sl.Len()-start+offset, sl.Len()+end-start)
 	t.Copy(sl.Slice(start-offset, sl.Len()))
@@ -128,7 +129,7 @@ func Stitch(dst, src Sliceable, fs feat.Set) error {
 	)
 	for _, f := range ff {
 		if f.End() < f.Start() {
-			return errors.New("sequtils: feature end < feature start")
+			return errors.ArgErr{}.Make("sequtils: feature end < feature start")
 		}
 	}
 	ff = append(feats(nil), ff...)
@@ -207,7 +208,7 @@ func Compose(dst, src Sliceable, fs feat.Set) error {
 	var tl int
 	for i, f := range ff {
 		if f.End() < f.Start() {
-			return errors.New("sequtils: feature end < feature start")
+			return errors.ArgErr{}.Make("sequtils: feature end < feature start")
 		}
 		l := min(f.End(), end) - max(f.Start(), offset)
 		tl += l
@@ -233,7 +234,7 @@ func Compose(dst, src Sliceable, fs feat.Set) error {
 					}
 				}
 			default:
-				return errors.New("sequtils: unable to reverse segment during compose")
+				return errors.ArgErr{}.Make("sequtils: unable to reverse segment during compose")
 			}
 			c = c.Append(r.Slice())
 		} else {

--- a/util/files.go
+++ b/util/files.go
@@ -5,10 +5,11 @@
 package util
 
 import (
-	"errors"
 	"hash"
 	"io"
 	"os"
+
+	"github.com/biogo/biogo/errors"
 )
 
 const (
@@ -22,7 +23,7 @@ var buffer = make([]byte, bufferLen)
 func Hash(h hash.Hash, f *os.File) (sum []byte, err error) {
 	fi, err := f.Stat()
 	if err != nil || fi.IsDir() {
-		return nil, errors.New("util: file is a directory")
+		return nil, errors.ArgErr{}.Make("util: file is a directory")
 	}
 
 	s := io.NewSectionReader(f, 0, fi.Size())


### PR DESCRIPTION
Relevant issue: https://github.com/biogo/biogo/issues/70

Broke down error types into ArgErr, StateErr and ConcurrencyErr
* ArgErr indicates that provided arguments are bad. These errors ideally
should not be raised within a contained system as the invalid data here
should be verifable ahead of time.
* StateErr indicates that the system has entered an invalid state. The
causes of these may be logic-based and are likely less immediately
apparent than simple argument validation.
* ConcurrencyErr indicates that something has gone wrong within the
concurrency model of Biogo. These errors are likely not easily
recoverable.

The existing logic within errors/errors.go was extended to provide easy
creation of errors from the already-defined errorBase struct

All tests passing. Only one test required update: this was due to
errorBase containing slice objects, thereby rendering it as
uncomparable.

As such, in the vast majority of cases these changes should be
non-breaking. Any extant logic which tests via string comparison will
continue to function, given that errorBase implements the T.Error()
requirement for the error interface.

If we are uncomfortable with the risk of comparison-logic being broken,
`errorBase` can be reduced to a comparable struct by removing any relevant inner info. 

Please take a look.
